### PR TITLE
Automatically pad the formatted input size to 2^k

### DIFF
--- a/src/ahp/constraint_systems.rs
+++ b/src/ahp/constraint_systems.rs
@@ -66,6 +66,21 @@ pub(crate) fn padded_matrix_dim(num_formatted_variables: usize, num_constraints:
     core::cmp::max(num_formatted_variables, num_constraints)
 }
 
+pub(crate) fn pad_input_for_indexer_and_prover<F: PrimeField>(cs: ConstraintSystemRef<F>) {
+    let formatted_input_size = cs.num_instance_variables();
+
+    let domain_x = GeneralEvaluationDomain::<F>::new(formatted_input_size);
+    assert!(domain_x.is_some());
+
+    let padded_size = domain_x.unwrap().size();
+
+    if padded_size > formatted_input_size {
+        for _ in 0..(padded_size - formatted_input_size) {
+            cs.new_input_variable(|| Ok(F::zero())).unwrap();
+        }
+    }
+}
+
 pub(crate) fn make_matrices_square<F: Field>(
     cs: ConstraintSystemRef<F>,
     num_formatted_variables: usize,

--- a/src/ahp/indexer.rs
+++ b/src/ahp/indexer.rs
@@ -12,6 +12,7 @@ use derivative::Derivative;
 
 use crate::ahp::constraint_systems::{
     balance_matrices, make_matrices_square_for_indexer, num_non_zero,
+    pad_input_for_indexer_and_prover,
 };
 use core::marker::PhantomData;
 
@@ -120,6 +121,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
         end_timer!(constraint_time);
 
         let padding_time = start_timer!(|| "Padding matrices to make them square");
+        pad_input_for_indexer_and_prover(ics.clone());
         make_matrices_square_for_indexer(ics.clone());
         end_timer!(padding_time);
         let matrix_processing_time = start_timer!(|| "Processing matrices");

--- a/src/ahp/prover.rs
+++ b/src/ahp/prover.rs
@@ -4,7 +4,9 @@ use crate::ahp::indexer::*;
 use crate::ahp::verifier::*;
 use crate::ahp::*;
 
-use crate::ahp::constraint_systems::{make_matrices_square_for_prover, unformat_public_input};
+use crate::ahp::constraint_systems::{
+    make_matrices_square_for_prover, pad_input_for_indexer_and_prover, unformat_public_input,
+};
 use crate::{ToString, Vec};
 use ark_ff::{Field, PrimeField, Zero};
 use ark_poly::{
@@ -145,6 +147,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
         end_timer!(constraint_time);
 
         let padding_time = start_timer!(|| "Padding matrices to make them square");
+        pad_input_for_indexer_and_prover(pcs.clone());
         make_matrices_square_for_prover(pcs.clone());
         end_timer!(padding_time);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,11 +323,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> 
             let domain_x = GeneralEvaluationDomain::<F>::new(public_input.len() + 1).unwrap();
 
             let mut unpadded_input = public_input.to_vec();
-            let padded_size = domain_x.size();
-
-            if padded_size - 1 > unpadded_input.len() {
-                unpadded_input.resize(padded_size - 1, F::zero());
-            }
+            unpadded_input.resize(core::cmp::max(public_input.len(), domain_x.size() - 1), F::zero());
 
             unpadded_input
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,10 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> 
             let domain_x = GeneralEvaluationDomain::<F>::new(public_input.len() + 1).unwrap();
 
             let mut unpadded_input = public_input.to_vec();
-            unpadded_input.resize(core::cmp::max(public_input.len(), domain_x.size() - 1), F::zero());
+            unpadded_input.resize(
+                core::cmp::max(public_input.len(), domain_x.size() - 1),
+                F::zero(),
+            );
 
             unpadded_input
         };


### PR DESCRIPTION
This PR automatically adjusts the formatted input to size 2^k by adding zero elements. This will allow the Marlin library to support a public input of arbitrary size.

In history, it seems intentional to require (unformatted) input to have size 2^k - 1. Therefore, I hereby request a review from @Pratyush.

The test is updated as well.