### PR TITLE
Remove circuit `C` and some lifetime specifiers from the type

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ rustup install stable
 
 After that, use `cargo` (the standard Rust build tool) to build the library:
 ```bash
-git clone https://github.com/scipr-lab/marlin.git
+git clone https://github.com/arkworks-rs/marlin.git
 cd marlin
 cargo build --release
 ```

--- a/src/ahp/mod.rs
+++ b/src/ahp/mod.rs
@@ -98,7 +98,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
     }
 
     /// Get all the strict degree bounds enforced in the AHP.
-    pub fn get_degree_bounds<C>(info: &indexer::IndexInfo<F, C>) -> [usize; 2] {
+    pub fn get_degree_bounds(info: &indexer::IndexInfo<F>) -> [usize; 2] {
         let mut degree_bounds = [0usize; 2];
         let num_constraints = info.num_constraints;
         let num_non_zero = info.num_non_zero;
@@ -112,13 +112,12 @@ impl<F: PrimeField> AHPForR1CS<F> {
 
     /// Construct the linear combinations that are checked by the AHP.
     #[allow(non_snake_case)]
-    pub fn construct_linear_combinations<C, E>(
+    pub fn construct_linear_combinations<E>(
         public_input: &[F],
         evals: &E,
-        state: &verifier::VerifierState<F, C>,
+        state: &verifier::VerifierState<F>,
     ) -> Result<Vec<LinearCombination<F>>, Error>
     where
-        C: ark_relations::r1cs::ConstraintSynthesizer<F>,
         E: EvaluationsProvider<F>,
     {
         let domain_h = state.domain_h;
@@ -127,7 +126,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
 
         let public_input = constraint_systems::format_public_input(public_input);
         if !Self::formatted_public_input_is_admissible(&public_input) {
-            Err(Error::InvalidPublicInputLength)?
+            return Err(Error::InvalidPublicInputLength);
         }
         let x_domain = GeneralEvaluationDomain::new(public_input.len())
             .ok_or(SynthesisError::PolynomialDegreeTooLarge)?;

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -4,9 +4,7 @@ use crate::Vec;
 use ark_ff::PrimeField;
 use ark_poly::univariate::DensePolynomial;
 use ark_poly_commit::{BatchLCProof, PolynomialCommitment};
-use ark_relations::r1cs::ConstraintSynthesizer;
 use ark_std::format;
-use core::marker::PhantomData;
 
 /* ************************************************************************* */
 /* ************************************************************************* */
@@ -20,25 +18,18 @@ pub type UniversalSRS<F, PC> = <PC as PolynomialCommitment<F, DensePolynomial<F>
 /* ************************************************************************* */
 
 /// Verification key for a specific index (i.e., R1CS matrices).
-pub struct IndexVerifierKey<
-    F: PrimeField,
-    PC: PolynomialCommitment<F, DensePolynomial<F>>,
-    C: ConstraintSynthesizer<F>,
-> {
+pub struct IndexVerifierKey<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>> {
     /// Stores information about the size of the index, as well as its field of
     /// definition.
-    pub index_info: IndexInfo<F, C>,
+    pub index_info: IndexInfo<F>,
     /// Commitments to the indexed polynomials.
     pub index_comms: Vec<PC::Commitment>,
     /// The verifier key for this index, trimmed from the universal SRS.
     pub verifier_key: PC::VerifierKey,
 }
 
-impl<
-        F: PrimeField,
-        PC: PolynomialCommitment<F, DensePolynomial<F>>,
-        C: ConstraintSynthesizer<F>,
-    > ark_ff::ToBytes for IndexVerifierKey<F, PC, C>
+impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>> ark_ff::ToBytes
+    for IndexVerifierKey<F, PC>
 {
     fn write<W: ark_std::io::Write>(&self, mut w: W) -> ark_std::io::Result<()> {
         self.index_info.write(&mut w)?;
@@ -46,11 +37,8 @@ impl<
     }
 }
 
-impl<
-        F: PrimeField,
-        PC: PolynomialCommitment<F, DensePolynomial<F>>,
-        C: ConstraintSynthesizer<F>,
-    > Clone for IndexVerifierKey<F, PC, C>
+impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>> Clone
+    for IndexVerifierKey<F, PC>
 {
     fn clone(&self) -> Self {
         Self {
@@ -61,12 +49,7 @@ impl<
     }
 }
 
-impl<
-        F: PrimeField,
-        PC: PolynomialCommitment<F, DensePolynomial<F>>,
-        C: ConstraintSynthesizer<F>,
-    > IndexVerifierKey<F, PC, C>
-{
+impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>> IndexVerifierKey<F, PC> {
     /// Iterate over the commitments to indexed polynomials in `self`.
     pub fn iter(&self) -> impl Iterator<Item = &PC::Commitment> {
         self.index_comms.iter()
@@ -78,28 +61,18 @@ impl<
 /* ************************************************************************* */
 
 /// Proving key for a specific index (i.e., R1CS matrices).
-pub struct IndexProverKey<
-    'a,
-    F: PrimeField,
-    PC: PolynomialCommitment<F, DensePolynomial<F>>,
-    C: ConstraintSynthesizer<F>,
-> {
+pub struct IndexProverKey<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>> {
     /// The index verifier key.
-    pub index_vk: IndexVerifierKey<F, PC, C>,
+    pub index_vk: IndexVerifierKey<F, PC>,
     /// The randomness for the index polynomial commitments.
     pub index_comm_rands: Vec<PC::Randomness>,
     /// The index itself.
-    pub index: Index<'a, F, C>,
+    pub index: Index<F>,
     /// The committer key for this index, trimmed from the universal SRS.
     pub committer_key: PC::CommitterKey,
 }
 
-impl<
-        'a,
-        F: PrimeField,
-        PC: PolynomialCommitment<F, DensePolynomial<F>>,
-        C: ConstraintSynthesizer<F>,
-    > Clone for IndexProverKey<'a, F, PC, C>
+impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>> Clone for IndexProverKey<F, PC>
 where
     PC::Commitment: Clone,
 {
@@ -118,11 +91,7 @@ where
 /* ************************************************************************* */
 
 /// A zkSNARK proof.
-pub struct Proof<
-    F: PrimeField,
-    PC: PolynomialCommitment<F, DensePolynomial<F>>,
-    C: ConstraintSynthesizer<F>,
-> {
+pub struct Proof<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>> {
     /// Commitments to the polynomials produced by the AHP prover.
     pub commitments: Vec<Vec<PC::Commitment>>,
     /// Evaluations of these polynomials.
@@ -131,16 +100,9 @@ pub struct Proof<
     pub prover_messages: Vec<ProverMsg<F>>,
     /// An evaluation proof from the polynomial commitment.
     pub pc_proof: BatchLCProof<F, DensePolynomial<F>, PC>,
-    #[doc(hidden)]
-    constraint_system: PhantomData<C>,
 }
 
-impl<
-        F: PrimeField,
-        PC: PolynomialCommitment<F, DensePolynomial<F>>,
-        C: ConstraintSynthesizer<F>,
-    > Proof<F, PC, C>
-{
+impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>> Proof<F, PC> {
     /// Construct a new proof.
     pub fn new(
         commitments: Vec<Vec<PC::Commitment>>,
@@ -153,7 +115,6 @@ impl<
             evaluations,
             prover_messages,
             pc_proof,
-            constraint_system: PhantomData,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,7 +310,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> 
 
     /// Verify that a proof for the constrain system defined by `C` asserts that
     /// all constraints are satisfied.
-    pub fn verify<C: ConstraintSynthesizer<F>, R: RngCore>(
+    pub fn verify<R: RngCore>(
         index_vk: &IndexVerifierKey<F, PC>,
         public_input: &[F],
         proof: &Proof<F, PC>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@ use digest::Digest;
 use rand_core::RngCore;
 
 use ark_std::{
-    borrow::Cow,
     collections::BTreeMap,
     format,
     marker::PhantomData,
@@ -99,7 +98,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> 
     pub fn index<C: ConstraintSynthesizer<F>>(
         srs: &UniversalSRS<F, PC>,
         c: C,
-    ) -> Result<(IndexProverKey<F, PC, C>, IndexVerifierKey<F, PC, C>), Error<PC::Error>> {
+    ) -> Result<(IndexProverKey<F, PC>, IndexVerifierKey<F, PC>), Error<PC::Error>> {
         let index_time = start_timer!(|| "Marlin::Index");
 
         // TODO: Add check that c is in the correct mode.
@@ -108,7 +107,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> 
             Err(Error::IndexTooLarge)?;
         }
 
-        let coeff_support = AHPForR1CS::get_degree_bounds::<C>(&index.index_info);
+        let coeff_support = AHPForR1CS::get_degree_bounds(&index.index_info);
         // Marlin only needs degree 2 random polynomials
         let supported_hiding_bound = 1;
         let (committer_key, verifier_key) = PC::trim(
@@ -135,7 +134,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> 
         };
 
         let index_pk = IndexProverKey {
-            index,
+            index: index.clone(),
             index_comm_rands,
             index_vk: index_vk.clone(),
             committer_key,
@@ -148,10 +147,10 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> 
 
     /// Create a zkSNARK asserting that the constraint system is satisfied.
     pub fn prove<C: ConstraintSynthesizer<F>, R: RngCore>(
-        index_pk: &IndexProverKey<F, PC, C>,
+        index_pk: &IndexProverKey<F, PC>,
         c: C,
         zk_rng: &mut R,
-    ) -> Result<Proof<F, PC, C>, Error<PC::Error>> {
+    ) -> Result<Proof<F, PC>, Error<PC::Error>> {
         let prover_time = start_timer!(|| "Marlin::Prover");
         // Add check that c is in the correct mode.
 
@@ -312,9 +311,9 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> 
     /// Verify that a proof for the constrain system defined by `C` asserts that
     /// all constraints are satisfied.
     pub fn verify<C: ConstraintSynthesizer<F>, R: RngCore>(
-        index_vk: &IndexVerifierKey<F, PC, C>,
+        index_vk: &IndexVerifierKey<F, PC>,
         public_input: &[F],
-        proof: &Proof<F, PC, C>,
+        proof: &Proof<F, PC>,
         rng: &mut R,
     ) -> Result<bool, Error<PC::Error>> {
         let verifier_time = start_timer!(|| "Marlin::Verify");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> 
         };
 
         let index_pk = IndexProverKey {
-            index: index.clone(),
+            index,
             index_comm_rands,
             index_vk: index_vk.clone(),
             committer_key,


### PR DESCRIPTION
This is an extracted part of the `constraints` PR. 

This part does two things:
- Remove unnecessary lifetime specifiers.
- Remove a few cows.
- Remove `C: CosntraintSynthesizer` from many of the data structures' type parameters, since it is somehow unnecessary.

This change might be breaking that may affect Ryan's project. 
So, I hereby request Ryan (@ryanleh) for a review.