### PR TITLE
Add serialization for Proof

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -67,7 +67,7 @@ impl<F: PrimeField> ConstraintSynthesizer<F> for DummyCircuit<F> {
 
 macro_rules! marlin_prove_bench {
     ($bench_name:ident, $bench_field:ty, $bench_pairing_engine:ty) => {
-        let rng = &mut ark_ff::test_rng();
+        let rng = &mut ark_std::test_rng();
         let c = DummyCircuit::<$bench_field> {
             a: Some(<$bench_field>::rand(rng)),
             b: Some(<$bench_field>::rand(rng)),

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,7 +3,7 @@
 // where N is the number of threads you want to use (N = 1 for single-thread).
 
 use ark_bls12_381::{Bls12_381, Fr as BlsFr};
-use ark_ff::{PrimeField, UniformRand};
+use ark_ff::PrimeField;
 use ark_marlin::Marlin;
 use ark_mnt4_298::{Fr as MNT4Fr, MNT4_298};
 use ark_mnt4_753::{Fr as MNT4BigFr, MNT4_753};
@@ -15,7 +15,7 @@ use ark_relations::{
     lc,
     r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
 };
-use ark_std::ops::Mul;
+use ark_std::{ops::Mul, UniformRand};
 use blake2::Blake2s;
 
 const NUM_PROVE_REPEATITIONS: usize = 10;
@@ -109,7 +109,7 @@ macro_rules! marlin_prove_bench {
 
 macro_rules! marlin_verify_bench {
     ($bench_name:ident, $bench_field:ty, $bench_pairing_engine:ty) => {
-        let rng = &mut ark_ff::test_rng();
+        let rng = &mut ark_std::test_rng();
         let c = DummyCircuit::<$bench_field> {
             a: Some(<$bench_field>::rand(rng)),
             b: Some(<$bench_field>::rand(rng)),

--- a/src/ahp/mod.rs
+++ b/src/ahp/mod.rs
@@ -4,8 +4,7 @@ use ark_poly::univariate::DensePolynomial;
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};
 use ark_poly_commit::{LCTerm, LinearCombination};
 use ark_relations::r1cs::SynthesisError;
-use ark_std::{cfg_iter_mut, format, vec};
-use core::{borrow::Borrow, marker::PhantomData};
+use ark_std::{borrow::Borrow, cfg_iter_mut, format, marker::PhantomData, vec};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -389,7 +388,7 @@ mod tests {
 
     #[test]
     fn domain_unnormalized_bivariate_lagrange_poly_diff_inputs() {
-        let rng = &mut ark_ff::test_rng();
+        let rng = &mut ark_std::test_rng();
         for domain_size in 1..10 {
             let domain = GeneralEvaluationDomain::<Fr>::new(1 << domain_size).unwrap();
             let x = Fr::rand(rng);
@@ -404,7 +403,7 @@ mod tests {
 
     #[test]
     fn test_summation() {
-        let rng = &mut ark_ff::test_rng();
+        let rng = &mut ark_std::test_rng();
         let size = 1 << 4;
         let domain = GeneralEvaluationDomain::<Fr>::new(1 << 4).unwrap();
         let size_as_fe = domain.size_as_field_element();

--- a/src/ahp/prover.rs
+++ b/src/ahp/prover.rs
@@ -95,11 +95,29 @@ impl<F: Field> CanonicalSerialize for ProverMsg<F> {
         };
         res.serialized_size()
     }
+
+    fn serialize_unchecked<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        let res: Option<Vec<F>> = match self {
+            ProverMsg::EmptyMessage => None,
+            ProverMsg::FieldElements(v) => Some(v.clone()),
+        };
+        res.serialize_unchecked(&mut writer)
+    }
 }
 
 impl<F: Field> CanonicalDeserialize for ProverMsg<F> {
     fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let res = Option::<Vec<F>>::deserialize(&mut reader)?;
+
+        if let Some(res) = res {
+            Ok(ProverMsg::FieldElements(res))
+        } else {
+            Ok(ProverMsg::EmptyMessage)
+        }
+    }
+
+    fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let res = Option::<Vec<F>>::deserialize_unchecked(&mut reader)?;
 
         if let Some(res) = res {
             Ok(ProverMsg::FieldElements(res))

--- a/src/ahp/prover.rs
+++ b/src/ahp/prover.rs
@@ -103,6 +103,22 @@ impl<F: Field> CanonicalSerialize for ProverMsg<F> {
         };
         res.serialize_unchecked(&mut writer)
     }
+
+    fn serialize_uncompressed<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        let res: Option<Vec<F>> = match self {
+            ProverMsg::EmptyMessage => None,
+            ProverMsg::FieldElements(v) => Some(v.clone()),
+        };
+        res.serialize_uncompressed(&mut writer)
+    }
+
+    fn uncompressed_size(&self) -> usize {
+        let res: Option<Vec<F>> = match self {
+            ProverMsg::EmptyMessage => None,
+            ProverMsg::FieldElements(v) => Some(v.clone()),
+        };
+        res.uncompressed_size()
+    }
 }
 
 impl<F: Field> CanonicalDeserialize for ProverMsg<F> {
@@ -118,6 +134,16 @@ impl<F: Field> CanonicalDeserialize for ProverMsg<F> {
 
     fn deserialize_unchecked<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
         let res = Option::<Vec<F>>::deserialize_unchecked(&mut reader)?;
+
+        if let Some(res) = res {
+            Ok(ProverMsg::FieldElements(res))
+        } else {
+            Ok(ProverMsg::EmptyMessage)
+        }
+    }
+
+    fn deserialize_uncompressed<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let res = Option::<Vec<F>>::deserialize_uncompressed(&mut reader)?;
 
         if let Some(res) = res {
             Ok(ProverMsg::FieldElements(res))

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -4,7 +4,11 @@ use crate::Vec;
 use ark_ff::PrimeField;
 use ark_poly::univariate::DensePolynomial;
 use ark_poly_commit::{BatchLCProof, PolynomialCommitment};
-use ark_std::format;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
+use ark_std::{
+    format,
+    io::{Read, Write},
+};
 
 /* ************************************************************************* */
 /* ************************************************************************* */
@@ -31,7 +35,7 @@ pub struct IndexVerifierKey<F: PrimeField, PC: PolynomialCommitment<F, DensePoly
 impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>> ark_ff::ToBytes
     for IndexVerifierKey<F, PC>
 {
-    fn write<W: ark_std::io::Write>(&self, mut w: W) -> ark_std::io::Result<()> {
+    fn write<W: Write>(&self, mut w: W) -> ark_std::io::Result<()> {
         self.index_info.write(&mut w)?;
         self.index_comms.write(&mut w)
     }
@@ -91,6 +95,7 @@ where
 /* ************************************************************************* */
 
 /// A zkSNARK proof.
+#[derive(CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>> {
     /// Commitments to the polynomials produced by the AHP prover.
     pub commitments: Vec<Vec<PC::Commitment>>,

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,6 +1,6 @@
 use crate::Vec;
 use ark_ff::{FromBytes, ToBytes};
-use core::marker::PhantomData;
+use ark_std::marker::PhantomData;
 use digest::{generic_array::GenericArray, Digest};
 use rand_chacha::ChaChaRng;
 use rand_core::{RngCore, SeedableRng};

--- a/src/test.rs
+++ b/src/test.rs
@@ -56,14 +56,14 @@ mod marlin {
     use ark_ff::UniformRand;
     use ark_poly::univariate::DensePolynomial;
     use ark_poly_commit::marlin_pc::MarlinKZG10;
+    use ark_std::ops::MulAssign;
     use blake2::Blake2s;
-    use core::ops::MulAssign;
 
     type MultiPC = MarlinKZG10<Bls12_381, DensePolynomial<Fr>>;
     type MarlinInst = Marlin<Fr, MultiPC, Blake2s>;
 
     fn test_circuit(num_constraints: usize, num_variables: usize) {
-        let rng = &mut ark_ff::test_rng();
+        let rng = &mut ark_std::test_rng();
 
         let universal_srs = MarlinInst::universal_setup(100, 25, 100, rng).unwrap();
 


### PR DESCRIPTION
This PR adds the serialization for Proof. 

A byproduct is that this PR adds serialization for ProverMsg, which is an enum type that automatic derivation panics. 