### PR TITLE
Fix the missing `outline_lcs` for prover

### DIFF
--- a/src/ahp/prover.rs
+++ b/src/ahp/prover.rs
@@ -222,7 +222,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
 
         let padding_time = start_timer!(|| "Padding matrices to make them square");
         pad_input_for_indexer_and_prover(pcs.clone());
-        ics.outline_lcs();
+        pcs.outline_lcs();
         make_matrices_square_for_prover(pcs.clone());
         end_timer!(padding_time);
 

--- a/src/ahp/prover.rs
+++ b/src/ahp/prover.rs
@@ -222,6 +222,7 @@ impl<F: PrimeField> AHPForR1CS<F> {
 
         let padding_time = start_timer!(|| "Padding matrices to make them square");
         pad_input_for_indexer_and_prover(pcs.clone());
+        ics.outline_lcs();
         make_matrices_square_for_prover(pcs.clone());
         end_timer!(padding_time);
 


### PR DESCRIPTION
This may suggest that we need to add a slightly more complicated circuit in the test files, so that missing `outline_lcs` would lead to a different R1CS constraint system.