### PR TITLE
Switch to panic='abort' for safety across FFI boundaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,17 @@ opt-level = 3
 lto = "thin"
 incremental = true
 debug = true
+panic = 'abort'
 
 [profile.test]
 opt-level = 3
 debug-assertions = true
 incremental = true
 debug = true
+
+[profile.dev]
+opt-level = 0
+panic = 'abort'
 
 [features]
 default = ["std", "parallel"]


### PR DESCRIPTION
cref arkworks-rs/algebra#183