### PR TITLE
Replace `rand_core` with `ark_std::rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ ark-poly = { git = "https://github.com/arkworks-rs/algebra", default-features = 
 ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features = false }
 ark-poly-commit = { git = "https://github.com/arkworks-rs/poly-commit", default-features = false }
 
-rand_core = { version = "0.5" }
 rand_chacha = { version = "0.2.1", default-features = false }
 rayon = { version = "1", optional = true }
 digest = { version = "0.9" }

--- a/src/ahp/prover.rs
+++ b/src/ahp/prover.rs
@@ -17,11 +17,11 @@ use ark_relations::r1cs::{
     ConstraintSynthesizer, ConstraintSystem, OptimizationGoal, SynthesisError,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
+use ark_std::rand::RngCore;
 use ark_std::{
     cfg_into_iter, cfg_iter, cfg_iter_mut,
     io::{Read, Write},
 };
-use rand_core::RngCore;
 
 /// State for the AHP prover.
 pub struct ProverState<'a, F: PrimeField> {

--- a/src/ahp/verifier.rs
+++ b/src/ahp/verifier.rs
@@ -2,7 +2,7 @@
 
 use crate::ahp::indexer::IndexInfo;
 use crate::ahp::*;
-use rand_core::RngCore;
+use ark_std::rand::RngCore;
 
 use ark_ff::PrimeField;
 use ark_poly::{EvaluationDomain, GeneralEvaluationDomain};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ use ark_poly::{univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationD
 use ark_poly_commit::Evaluations;
 use ark_poly_commit::{LabeledCommitment, PCUniversalParams, PolynomialCommitment};
 use ark_relations::r1cs::ConstraintSynthesizer;
+use ark_std::rand::RngCore;
 use digest::Digest;
-use rand_core::RngCore;
 
 use ark_std::{
     collections::BTreeMap,

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,9 +1,9 @@
 use crate::Vec;
 use ark_ff::{FromBytes, ToBytes};
 use ark_std::marker::PhantomData;
+use ark_std::rand::{RngCore, SeedableRng};
 use digest::{generic_array::GenericArray, Digest};
 use rand_chacha::ChaChaRng;
-use rand_core::{RngCore, SeedableRng};
 
 /// A `SeedableRng` that refreshes its seed by hashing together the previous seed
 /// and the new seed material.
@@ -32,7 +32,7 @@ impl<D: Digest> RngCore for FiatShamirRng<D> {
     }
 
     #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), ark_std::rand::Error> {
         Ok(self.r.fill_bytes(dest))
     }
 }


### PR DESCRIPTION
## Description

As part of the efforts to bump the version of `rand`, this PR replaces the usage of `rand` in Marlin with invocations of `ark_std::rand`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [X] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` --- N/A, this is a simple change that does not affect a developer who uses this library
- [x] Re-reviewed `Files changed` in the Github PR explorer
