### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
-## v0.2.0
+# CHANGELOG
+
+## Pending
 
 ### Breaking changes
 
 ### Features
-- #47 Automatically pad input to be of length 2^k, so constraint writers can have a public input of any size
-- #51 Implement CanonicalSerialize for Marlin's proofs.
-- #54 Implement CanonicalSerialize for Marlin's Index and Index Verification Key.
 
 ### Improvements
 
 ### Bug fixes
+
+## v0.3.0
+
+- Change dependency to version `0.3.0` of other arkworks-rs crates.
+
+## v0.2.0
+
+### Features
+
+- [\#47](https://github.com/arkworks-rs/marlin/pull/47) Automatically pad input to be of length 2^k, so constraint writers can have a public input of any size
+- [\#51](https://github.com/arkworks-rs/marlin/pull/51) Implement CanonicalSerialize for Marlin's proofs.
+- [\#54](https://github.com/arkworks-rs/marlin/pull/54) Implement CanonicalSerialize for Marlin's Index and Index Verification Key.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-marlin"
-version = "0.2.1-alpha.0"
+version = "0.3.0"
 authors = [
   "Alessandro Chiesa <alexch@berkeley.edu>",
   "Mary Maller <mary.maller.15@ucl.ac.uk>",
@@ -20,25 +20,25 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-ark-serialize = { version = "^0.2.0", default-features = false, features = [ "derive" ] }
-ark-ff = { version = "^0.2.0", default-features = false }
-ark-std = { version = "^0.2.0", default-features = false }
-ark-poly = { version = "^0.2.0", default-features = false }
-ark-relations = { version = "^0.2.0", default-features = false }
-ark-poly-commit = { version = "^0.2.0", default-features = false }
+ark-serialize = { version = "^0.3.0", default-features = false, features = [ "derive" ] }
+ark-ff = { version = "^0.3.0", default-features = false }
+ark-std = { version = "^0.3.0", default-features = false }
+ark-poly = { version = "^0.3.0", default-features = false }
+ark-relations = { version = "^0.3.0", default-features = false }
+ark-poly-commit = { version = "^0.3.0", default-features = false }
 
-rand_chacha = { version = "0.2.1", default-features = false }
+rand_chacha = { version = "0.3.0", default-features = false }
 rayon = { version = "1", optional = true }
 digest = { version = "0.9" }
 derivative = { version = "2", features = ["use_core"] }
 
 [dev-dependencies]
 blake2 = { version = "0.9", default-features = false }
-ark-bls12-381 = { version = "^0.2.0", default-features = false, features = [ "curve" ] }
-ark-mnt4-298 = { version = "^0.2.0", default-features = false, features = ["r1cs", "curve"] }
-ark-mnt6-298 = { version = "^0.2.0", default-features = false, features = ["r1cs"] }
-ark-mnt4-753 = { version = "^0.2.0", default-features = false, features = ["r1cs", "curve"] }
-ark-mnt6-753 = { version = "^0.2.0", default-features = false, features = ["r1cs"] }
+ark-bls12-381 = { version = "^0.3.0", default-features = false, features = [ "curve" ] }
+ark-mnt4-298 = { version = "^0.3.0", default-features = false, features = ["r1cs", "curve"] }
+ark-mnt6-298 = { version = "^0.3.0", default-features = false, features = ["r1cs"] }
+ark-mnt4-753 = { version = "^0.3.0", default-features = false, features = ["r1cs", "curve"] }
+ark-mnt6-753 = { version = "^0.3.0", default-features = false, features = ["r1cs"] }
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
## Description

This PR prepares `ark-marlin` to 0.3.0. Note that the version of `rand_chacha` has to be bumped in order to be compatible with rand 0.8 used in 0.3.0.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

n/a: 
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`