### PR TITLE
Make marker public in IndexInfo

### DIFF
--- a/src/ahp/indexer.rs
+++ b/src/ahp/indexer.rs
@@ -39,7 +39,7 @@ pub struct IndexInfo<F> {
     pub num_instance_variables: usize,
 
     #[doc(hidden)]
-    f: PhantomData<F>,
+    pub f: PhantomData<F>,
 }
 
 impl<F: PrimeField> ark_ff::ToBytes for IndexInfo<F> {


### PR DESCRIPTION
## Description

I want to be able to create an `IndexInfo` instance by passing all the fields.
Does this require a changelog entry?
