### PR TITLE
Unify the interface for Fiat-Shamir transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+- [\#86](https://github.com/arkworks-rs/marlin/pull/86) Unify the interface for Fiat-Shamir transform.
+
 ### Features
 
 ### Improvements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ ark-poly = { version = "^0.3.0", default-features = false }
 ark-relations = { version = "^0.3.0", default-features = false }
 ark-poly-commit = { version = "^0.3.0", default-features = false }
 
-rand_chacha = { version = "0.3.0", default-features = false }
 rayon = { version = "1", optional = true }
 digest = { version = "0.9" }
 derivative = { version = "2", features = ["use_core"] }
 
 [dev-dependencies]
+rand_chacha = { version = "0.3.0", default-features = false }
 blake2 = { version = "0.9", default-features = false }
 ark-bls12-381 = { version = "^0.3.0", default-features = false, features = [ "curve" ] }
 ark-mnt4-298 = { version = "^0.3.0", default-features = false, features = ["r1cs", "curve"] }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,7 +4,7 @@
 
 use ark_bls12_381::{Bls12_381, Fr as BlsFr};
 use ark_ff::PrimeField;
-use ark_marlin::Marlin;
+use ark_marlin::{Marlin, SimpleHashFiatShamirRng};
 use ark_mnt4_298::{Fr as MNT4Fr, MNT4_298};
 use ark_mnt4_753::{Fr as MNT4BigFr, MNT4_753};
 use ark_mnt6_298::{Fr as MNT6Fr, MNT6_298};
@@ -17,6 +17,7 @@ use ark_relations::{
 };
 use ark_std::{ops::Mul, UniformRand};
 use blake2::Blake2s;
+use rand_chacha::ChaChaRng;
 
 const NUM_PROVE_REPEATITIONS: usize = 10;
 const NUM_VERIFY_REPEATITIONS: usize = 50;
@@ -78,13 +79,13 @@ macro_rules! marlin_prove_bench {
         let srs = Marlin::<
             $bench_field,
             SonicKZG10<$bench_pairing_engine, DensePolynomial<$bench_field>>,
-            Blake2s,
+            SimpleHashFiatShamirRng<Blake2s, ChaChaRng>,
         >::universal_setup(65536, 65536, 3 * 65536, rng)
         .unwrap();
         let (pk, _) = Marlin::<
             $bench_field,
             SonicKZG10<$bench_pairing_engine, DensePolynomial<$bench_field>>,
-            Blake2s,
+            SimpleHashFiatShamirRng<Blake2s, ChaChaRng>,
         >::index(&srs, c)
         .unwrap();
 
@@ -94,7 +95,7 @@ macro_rules! marlin_prove_bench {
             let _ = Marlin::<
                 $bench_field,
                 SonicKZG10<$bench_pairing_engine, DensePolynomial<$bench_field>>,
-                Blake2s,
+                SimpleHashFiatShamirRng<Blake2s, ChaChaRng>,
             >::prove(&pk, c.clone(), rng)
             .unwrap();
         }
@@ -120,19 +121,19 @@ macro_rules! marlin_verify_bench {
         let srs = Marlin::<
             $bench_field,
             SonicKZG10<$bench_pairing_engine, DensePolynomial<$bench_field>>,
-            Blake2s,
+            SimpleHashFiatShamirRng<Blake2s, ChaChaRng>,
         >::universal_setup(65536, 65536, 3 * 65536, rng)
         .unwrap();
         let (pk, vk) = Marlin::<
             $bench_field,
             SonicKZG10<$bench_pairing_engine, DensePolynomial<$bench_field>>,
-            Blake2s,
+            SimpleHashFiatShamirRng<Blake2s, ChaChaRng>,
         >::index(&srs, c)
         .unwrap();
         let proof = Marlin::<
             $bench_field,
             SonicKZG10<$bench_pairing_engine, DensePolynomial<$bench_field>>,
-            Blake2s,
+            SimpleHashFiatShamirRng<Blake2s, ChaChaRng>,
         >::prove(&pk, c.clone(), rng)
         .unwrap();
 
@@ -144,7 +145,7 @@ macro_rules! marlin_verify_bench {
             let _ = Marlin::<
                 $bench_field,
                 SonicKZG10<$bench_pairing_engine, DensePolynomial<$bench_field>>,
-                Blake2s,
+                SimpleHashFiatShamirRng<Blake2s, ChaChaRng>,
             >::verify(&vk, &vec![v], &proof, rng)
             .unwrap();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,9 @@ pub struct Marlin<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>
     #[doc(hidden)] PhantomData<FS>,
 );
 
-impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, FS: FiatShamirRng> Marlin<F, PC, FS> {
+impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, FS: FiatShamirRng>
+    Marlin<F, PC, FS>
+{
     /// The personalization string for this protocol. Used to personalize the
     /// Fiat-Shamir rng.
     pub const PROTOCOL_NAME: &'static [u8] = b"MARLIN-2019";
@@ -329,9 +331,8 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, FS: FiatSha
             unpadded_input
         };
 
-        let mut fs_rng = FS::initialize(
-            &to_bytes![&Self::PROTOCOL_NAME, &index_vk, &public_input].unwrap(),
-        );
+        let mut fs_rng =
+            FS::initialize(&to_bytes![&Self::PROTOCOL_NAME, &index_vk, &public_input].unwrap());
 
         // --------------------------------------------------------------------
         // First round

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ macro_rules! eprintln {
 /// the seed based on new messages in the proof transcript.
 pub mod rng;
 use rng::FiatShamirRng;
+pub use rng::SimpleHashFiatShamirRng;
 
 mod error;
 pub use error::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ use ark_poly_commit::Evaluations;
 use ark_poly_commit::{LabeledCommitment, PCUniversalParams, PolynomialCommitment};
 use ark_relations::r1cs::ConstraintSynthesizer;
 use ark_std::rand::RngCore;
-use digest::Digest;
 
 use ark_std::{
     collections::BTreeMap,
@@ -61,13 +60,13 @@ use ahp::EvaluationsProvider;
 mod test;
 
 /// The compiled argument system.
-pub struct Marlin<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest>(
+pub struct Marlin<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, FS: FiatShamirRng>(
     #[doc(hidden)] PhantomData<F>,
     #[doc(hidden)] PhantomData<PC>,
-    #[doc(hidden)] PhantomData<D>,
+    #[doc(hidden)] PhantomData<FS>,
 );
 
-impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> Marlin<F, PC, D> {
+impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, FS: FiatShamirRng> Marlin<F, PC, FS> {
     /// The personalization string for this protocol. Used to personalize the
     /// Fiat-Shamir rng.
     pub const PROTOCOL_NAME: &'static [u8] = b"MARLIN-2019";
@@ -156,7 +155,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> 
 
         let prover_init_state = AHPForR1CS::prover_init(&index_pk.index, c)?;
         let public_input = prover_init_state.public_input();
-        let mut fs_rng = FiatShamirRng::<D>::from_seed(
+        let mut fs_rng = FS::initialize(
             &to_bytes![&Self::PROTOCOL_NAME, &index_pk.index_vk, &public_input].unwrap(),
         );
 
@@ -330,7 +329,7 @@ impl<F: PrimeField, PC: PolynomialCommitment<F, DensePolynomial<F>>, D: Digest> 
             unpadded_input
         };
 
-        let mut fs_rng = FiatShamirRng::<D>::from_seed(
+        let mut fs_rng = FS::initialize(
             &to_bytes![&Self::PROTOCOL_NAME, &index_vk, &public_input].unwrap(),
         );
 

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -56,7 +56,7 @@ where
         initial_input
             .write(&mut bytes)
             .expect("failed to convert to bytes");
-        let seed = FromBytes::read(D::digest(&bytes).as_ref()).expect("failed to get [u32; 8]");
+        let seed = FromBytes::read(D::digest(&bytes).as_ref()).expect("failed to get [u8; 32]");
         let r = R::from_seed(<R::Seed>::from(seed));
         Self {
             r,
@@ -74,7 +74,7 @@ where
             .write(&mut bytes)
             .expect("failed to convert to bytes");
         bytes.extend_from_slice(&self.seed);
-        self.seed = FromBytes::read(D::digest(&bytes).as_ref()).expect("failed to get [u32; 8]");
+        self.seed = FromBytes::read(D::digest(&bytes).as_ref()).expect("failed to get [u8; 32]");
         self.r = R::from_seed(<R::Seed>::from(self.seed));
     }
 }

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,10 +1,9 @@
 use crate::Vec;
 use ark_ff::{FromBytes, ToBytes};
-use ark_std::marker::PhantomData;
 use ark_std::convert::From;
+use ark_std::marker::PhantomData;
 use ark_std::rand::{RngCore, SeedableRng};
 use digest::Digest;
-
 
 /// An RNG suitable for Fiat-Shamir transforms
 pub trait FiatShamirRng: RngCore {
@@ -13,7 +12,6 @@ pub trait FiatShamirRng: RngCore {
     /// Absorb new inputs into state
     fn absorb<'a, T: 'a + ToBytes>(&mut self, new_input: &'a T);
 }
-
 
 /// A simple `FiatShamirRng` that refreshes its seed by hashing together the previous seed
 /// and the new seed material.
@@ -47,15 +45,17 @@ impl<D: Digest, R: RngCore + SeedableRng> RngCore for SimpleHashFiatShamirRng<D,
 }
 
 impl<D: Digest, R: RngCore + SeedableRng> FiatShamirRng for SimpleHashFiatShamirRng<D, R>
-    where
-        R::Seed: From<[u8; 32]>,
+where
+    R::Seed: From<[u8; 32]>,
 {
     /// Create a new `Self` by initializing with a fresh seed.
     /// `self.seed = H(initial_input)`.
     #[inline]
     fn initialize<'a, T: 'a + ToBytes>(initial_input: &'a T) -> Self {
         let mut bytes = Vec::new();
-        initial_input.write(&mut bytes).expect("failed to convert to bytes");
+        initial_input
+            .write(&mut bytes)
+            .expect("failed to convert to bytes");
         let seed = FromBytes::read(D::digest(&bytes).as_ref()).expect("failed to get [u32; 8]");
         let r = R::from_seed(<R::Seed>::from(seed));
         Self {
@@ -70,7 +70,9 @@ impl<D: Digest, R: RngCore + SeedableRng> FiatShamirRng for SimpleHashFiatShamir
     #[inline]
     fn absorb<'a, T: 'a + ToBytes>(&mut self, new_input: &'a T) {
         let mut bytes = Vec::new();
-        new_input.write(&mut bytes).expect("failed to convert to bytes");
+        new_input
+            .write(&mut bytes)
+            .expect("failed to convert to bytes");
         bytes.extend_from_slice(&self.seed);
         self.seed = FromBytes::read(D::digest(&bytes).as_ref()).expect("failed to get [u32; 8]");
         self.r = R::from_seed(<R::Seed>::from(self.seed));

--- a/src/test.rs
+++ b/src/test.rs
@@ -115,7 +115,7 @@ impl<F: Field> ConstraintSynthesizer<F> for OutlineTestCircuit<F> {
 
 mod marlin {
     use super::*;
-    use crate::{Marlin, rng::SimpleHashFiatShamirRng};
+    use crate::{rng::SimpleHashFiatShamirRng, Marlin};
 
     use ark_bls12_381::{Bls12_381, Fr};
     use ark_ff::UniformRand;

--- a/src/test.rs
+++ b/src/test.rs
@@ -115,7 +115,7 @@ impl<F: Field> ConstraintSynthesizer<F> for OutlineTestCircuit<F> {
 
 mod marlin {
     use super::*;
-    use crate::Marlin;
+    use crate::{Marlin, rng::SimpleHashFiatShamirRng};
 
     use ark_bls12_381::{Bls12_381, Fr};
     use ark_ff::UniformRand;
@@ -123,9 +123,11 @@ mod marlin {
     use ark_poly_commit::marlin_pc::MarlinKZG10;
     use ark_std::ops::MulAssign;
     use blake2::Blake2s;
+    use rand_chacha::ChaChaRng;
 
     type MultiPC = MarlinKZG10<Bls12_381, DensePolynomial<Fr>>;
-    type MarlinInst = Marlin<Fr, MultiPC, Blake2s>;
+    type FS = SimpleHashFiatShamirRng<Blake2s, ChaChaRng>;
+    type MarlinInst = Marlin<Fr, MultiPC, FS>;
 
     fn test_circuit(num_constraints: usize, num_variables: usize) {
         let rng = &mut ark_std::test_rng();

--- a/src/test.rs
+++ b/src/test.rs
@@ -115,7 +115,7 @@ impl<F: Field> ConstraintSynthesizer<F> for OutlineTestCircuit<F> {
 
 mod marlin {
     use super::*;
-    use crate::{rng::SimpleHashFiatShamirRng, Marlin};
+    use crate::{Marlin, SimpleHashFiatShamirRng};
 
     use ark_bls12_381::{Bls12_381, Fr};
     use ark_ff::UniformRand;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
This PR abstracts the functionality needed for creating Fiat-Shamir challenges in Marlin. It allows for choices of other primitives instead of the hard-coded `ChaChaRng` with hash seed currently used. This hard-coded choice makes it difficult to use Marlin for some applications, e.g., in a solidity verifier where keccak would be preferred over chacha (https://github.com/Zokrates/ZoKrates/pull/1103).

Other projects (https://github.com/AleoHQ/snarkVM/blob/testnet2/marlin/src/fiat_shamir/traits/fiat_shamir.rs#L28) have similarly abstracted out the Fiat-Shamir functionality for the purpose of using a SNARK-friendly hash.

This PR can serve as a quick fix to allow customizability of the Marlin proof system. If a more comprehensive solution that supports constraints is desired (following the above link), perhaps that can be added in the future.

This PR does the following:
- Adds a `FiatShamirRng` trait to abstract the functionality needed for creating Fiat-Shamir challenges
- Adds a `SimpleHashFiatShamirRng` struct that implements the functionality using the existing `SeedableRng` and `Digest` composition (the previous hard-coded functionality is obtained by instantiating with `ChaChaRng`)

Test strategy: `cargo test` succeeds for Marlin instantiated with `SimpleHashFiatShamirRng` with `ChaChaRng` and `Blake2s`.

---

## Checklist

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests (tests pass, no functionality change -- just a refactor)
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` (not sure what to add here)
- [x] Re-reviewed `Files changed` in the Github PR explorer
